### PR TITLE
Django 1.9 fixes

### DIFF
--- a/django_admin_bootstrapped/templates/admin/500.html
+++ b/django_admin_bootstrapped/templates/admin/500.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <ul class="breadcrumb">

--- a/django_admin_bootstrapped/templates/admin/app_index.html
+++ b/django_admin_bootstrapped/templates/admin/app_index.html
@@ -1,6 +1,5 @@
 {% extends "admin/index.html" %}
 {% load i18n bootstrapped_goodies_tags %}
-{% load url from future %}
 
 {% if not is_popup %}
 {% block breadcrumbs %}

--- a/django_admin_bootstrapped/templates/admin/auth/user/change_password.html
+++ b/django_admin_bootstrapped/templates/admin/auth/user/change_password.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_modify %}
-{% load url from future %}
 {% load admin_urls bootstrap3 %}
 
 {% block extrahead %}{{ block.super }}

--- a/django_admin_bootstrapped/templates/admin/base.html
+++ b/django_admin_bootstrapped/templates/admin/base.html
@@ -1,4 +1,4 @@
-{% load admin_static bootstrapped_goodies_tags %}{% load url from future %}
+{% load admin_static bootstrapped_goodies_tags %}
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" lang="{{ LANGUAGE_CODE|default:"en-us" }}" {% if LANGUAGE_BIDI %}dir="rtl"{% endif %}>
 <head>

--- a/django_admin_bootstrapped/templates/admin/base_site.html
+++ b/django_admin_bootstrapped/templates/admin/base_site.html
@@ -1,5 +1,5 @@
 {% extends "admin/base.html" %}
-{% load i18n %}{% load admin_static bootstrapped_goodies_tags %}{% load url from future %}
+{% load i18n %}{% load admin_static bootstrapped_goodies_tags %}
 
 {% block title %}{% render_with_template_if_exist "admin/admin_title.html" "Django administration" %} | {% trans 'Django site admin' %}{% endblock %}
 

--- a/django_admin_bootstrapped/templates/admin/change_form.html
+++ b/django_admin_bootstrapped/templates/admin/change_form.html
@@ -29,7 +29,8 @@
 {% if change %}{% if not is_popup %}
   <div class="pull-right" style="margin: 8px;">
     {% block object-tools-items %}
-    <a href="history/" class="btn btn-primary historylink">{% trans "History" %}</a>
+	{% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+    <a href="{% add_preserved_filters history_url %}" class="btn btn-primary historylink">{% trans "History" %}</a>
       {% if has_absolute_url %}
         <a href="../../../r/{{ content_type_id }}/{{ object_id }}/" class="btn btn-primary viewsitelink">
           {% trans "View on site" %}

--- a/django_admin_bootstrapped/templates/admin/change_form.html
+++ b/django_admin_bootstrapped/templates/admin/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_modify bootstrapped_goodies_tags %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block extrahead %}{{ block.super }}

--- a/django_admin_bootstrapped/templates/admin/change_list.html
+++ b/django_admin_bootstrapped/templates/admin/change_list.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static admin_list bootstrapped_goodies_tags %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block extrastyle %}

--- a/django_admin_bootstrapped/templates/admin/cms/page/change_form.html
+++ b/django_admin_bootstrapped/templates/admin/cms/page/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify cms_tags cms_admin %}
-{% load url from future %}
 {% block title %}{% trans "Change a page" %}{% endblock %}
 
 {% block extrahead %}

--- a/django_admin_bootstrapped/templates/admin/cms/page/plugin_change_form.html
+++ b/django_admin_bootstrapped/templates/admin/cms/page/plugin_change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_modify admin_urls admin_static cms_admin %}
-{% load url from future %}
 {% block extrahead %}{{ block.super }}
 <script type="text/javascript" src="{% admin_static_url %}js/jquery.min.js"></script>
 <script type="text/javascript" src="{{ STATIC_URL }}cms/js/csrf.js"></script>

--- a/django_admin_bootstrapped/templates/admin/delete_confirmation.html
+++ b/django_admin_bootstrapped/templates/admin/delete_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block breadcrumbs %}

--- a/django_admin_bootstrapped/templates/admin/delete_selected_confirmation.html
+++ b/django_admin_bootstrapped/templates/admin/delete_selected_confirmation.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n l10n %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block breadcrumbs %}

--- a/django_admin_bootstrapped/templates/admin/filer/breadcrumbs.html
+++ b/django_admin_bootstrapped/templates/admin/filer/breadcrumbs.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 
 <ol class="breadcrumb">
     <li><a href="{% url 'admin:index' %}" title="{% trans "Go back to admin homepage" %}">{% trans "Home" %}</a></li>

--- a/django_admin_bootstrapped/templates/admin/filer/folder/change_form.html
+++ b/django_admin_bootstrapped/templates/admin/filer/folder/change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/change_form.html" %}
 {% load i18n admin_modify admin_urls admin_static filermedia %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/admin/filer/folder/directory_listing.html
+++ b/django_admin_bootstrapped/templates/admin/filer/folder/directory_listing.html
@@ -1,6 +1,5 @@
 {% extends "admin/filer/base_site.html" %}
 {% load admin_urls admin_static filer_admin_tags filermedia i18n %}
-{% load url from future %}
 
 {% block extrahead %}{{ block.super }}
 {# upload stuff #}
@@ -72,9 +71,9 @@
 
     <div class="span9">
 <div id="content-main">
-    
+
     <div class="module" id="changelist">
-        
+
         {% if not folder.is_root %}
         <h1>{% if folder.parent %}<a href="{% url 'admin:filer-directory_listing' folder.parent.id %}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% trans "Go back to the parent folder" %}">&uarr;</a>{% else %}<a href="{% url 'admin:filer-directory_listing-root' %}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% trans "Go back to" %} {% trans "root"|title %} {% trans "folder" %}">&uarr;</a>{% endif %}
             <img src="{{ folder.icons.32 }}" alt="{% trans "Folder Icon" %}" /> {{ folder.name }}

--- a/django_admin_bootstrapped/templates/admin/filer/folder/directory_table.html
+++ b/django_admin_bootstrapped/templates/admin/filer/folder/directory_table.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load admin_urls admin_static admin_list filermedia filer_tags %}
-{% load url from future %}
 
 <div id="toolbartable">
     <table cellspacing="0" class="table table-striped">
@@ -67,11 +66,11 @@
 
                         <a class="btn btn-mini changelink" href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}"><i class="icon-edit"></i>{% trans "Change" %}</a>
                     </div>
-                    
+
                     <div>
                         <b><a href="{{ file.get_admin_url_path }}{% if is_popup %}?_popup=1{% if select_folder %}&select_folder=1{% endif %}{% endif %}" title="{% blocktrans with file.label as item_label %}Change '{{ item_label }}' details{% endblocktrans %}">{{ file.label }}</a></b><span class="tiny"> ({{ file.size|filesize:"auto1000long" }}{% ifequal file.file_type "Image" %}, {{ file.width }}x{{ file.height }} px{% endifequal %})</span>
                     </div>
-                    
+
                     <div>
                         {% trans "Owner" %}: {{ file.owner|default:"n/a" }}</div>
                         {% if enable_permissions %}

--- a/django_admin_bootstrapped/templates/admin/filer/tools/clipboard/clipboard.html
+++ b/django_admin_bootstrapped/templates/admin/filer/tools/clipboard/clipboard.html
@@ -1,5 +1,4 @@
 {% load thumbnail i18n %}
-{% load url from future %}
 
 {% for clipboard in user.filer_clipboards.all %}
 

--- a/django_admin_bootstrapped/templates/admin/invalid_setup.html
+++ b/django_admin_bootstrapped/templates/admin/invalid_setup.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/admin/login.html
+++ b/django_admin_bootstrapped/templates/admin/login.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_static bootstrap3 %}
-{% load url from future %}
 
 {% block nav-global %}{% endblock %}
 

--- a/django_admin_bootstrapped/templates/admin/object_history.html
+++ b/django_admin_bootstrapped/templates/admin/object_history.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n %}
-{% load url from future %}
 {% load admin_urls %}
 
 {% block breadcrumbs %}

--- a/django_admin_bootstrapped/templates/admin/submit_line.html
+++ b/django_admin_bootstrapped/templates/admin/submit_line.html
@@ -1,7 +1,10 @@
-{% load i18n %}
+{% load i18n admin_urls %}
 <div class="navbar navbar-default" style="padding: 8px">
   <div class="pull-left">
-      {% if show_delete_link %}<a class="btn btn-danger deletelink" href="delete/">{% trans "Delete" %}</a>{% endif %}
+      {% if show_delete_link %}
+	  {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+	  <a class="btn btn-danger deletelink" href="{% add_preserved_filters delete_url %}">{% trans "Delete" %}</a>
+	  {% endif %}
   </div>
 
   <div class="btn-group pull-right">

--- a/django_admin_bootstrapped/templates/admin_doc/template_filter_index.html
+++ b/django_admin_bootstrapped/templates/admin_doc/template_filter_index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load firstof from future %}
+{% load i18n %}
 
 {% block coltype %}colSM{% endblock %}
 {% block breadcrumbs %}

--- a/django_admin_bootstrapped/templates/admin_doc/template_tag_index.html
+++ b/django_admin_bootstrapped/templates/admin_doc/template_tag_index.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load firstof from future %}
+{% load i18n %}
 
 {% block coltype %}colSM{% endblock %}
 {% block breadcrumbs %}

--- a/django_admin_bootstrapped/templates/registration/logged_out.html
+++ b/django_admin_bootstrapped/templates/registration/logged_out.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load url from future %}{% load i18n %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 {% endblock %}

--- a/django_admin_bootstrapped/templates/registration/password_change_done.html
+++ b/django_admin_bootstrapped/templates/registration/password_change_done.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/registration/password_change_form.html
+++ b/django_admin_bootstrapped/templates/registration/password_change_form.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n static %}
-{% load url from future %}
 {% block extrastyle %}{{ block.super }}<link rel="stylesheet" type="text/css" href="{% static "admin/css/forms.css" %}" />{% endblock %}
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/registration/password_reset_complete.html
+++ b/django_admin_bootstrapped/templates/registration/password_reset_complete.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/registration/password_reset_confirm.html
+++ b/django_admin_bootstrapped/templates/registration/password_reset_confirm.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/registration/password_reset_done.html
+++ b/django_admin_bootstrapped/templates/registration/password_reset_done.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templates/registration/password_reset_form.html
+++ b/django_admin_bootstrapped/templates/registration/password_reset_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/base_site.html" %}
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 
 {% block breadcrumbs %}
 <ol class="breadcrumb">

--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -8,7 +8,7 @@ register = template.Library()
 def render_with_template_if_exist(context, template, fallback):
     text = fallback
     try:
-        text = render_to_string(template, context)
+        text = render_to_string(template, context.dictionary)
     except:
         pass
     return text

--- a/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
+++ b/django_admin_bootstrapped/templatetags/bootstrapped_goodies_tags.py
@@ -28,7 +28,7 @@ def language_selector(context):
         template = "admin/language_selector.html"
         context['i18n_is_set'] = True
         try:
-            output = render_to_string(template, context)
+            output = render_to_string(template, context.dictionary)
         except:
             pass
     return output

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django>=1.6.5
-django-extensions>=1.3.7
+django
+django-extensions
 django-bootstrap3
 
 # for django dates


### PR DESCRIPTION
* RemovedInDjango19Warning: Loading the `url` tag from the `future` library is deprecated and will be removed in Django 1.9. Use the default `url` tag instead.
* RemovedInDjango110Warning: render() must be called with a dict, not a RequestContext.